### PR TITLE
Testing SSH in clixon example container

### DIFF
--- a/openconfig/docker/Dockerfile
+++ b/openconfig/docker/Dockerfile
@@ -117,6 +117,19 @@ EXPOSE 80/tcp
 # Create clicon user and group
 RUN adduser -D -H clicon
 
+# Add ssh daemon and user account with password
+EXPOSE 22/tcp
+EXPOSE 830/tcp
+
+RUN apk add --no-cache openssh
+COPY src/sshd_config /etc/ssh/sshd_config
+
+RUN adduser -h /home/noc -s /bin/sh -D noc
+RUN adduser noc clicon
+RUN echo -n 'noc:noc' | chpasswd
+
+RUN rm /etc/motd && echo "Clixon OpenConfig Demo" > /etc/motd
+
 # Copy from stage 1
 COPY --from=0 /clixon/build/ /
 COPY --from=0 /usr/local/share/openconfig/* /usr/local/share/openconfig/

--- a/openconfig/docker/startsystem.sh
+++ b/openconfig/docker/startsystem.sh
@@ -51,9 +51,14 @@ DBG=${DBG:-0}
 # sudo: setrlimit(RLIMIT_CORE): Operation not permitted
 echo "Set disable_coredump false" > /etc/sudo.conf
 
+chown noc:noc /home/noc
+
 # Start clixon backend
 >&2 echo "start clixon_backend:"
-/usr/local/sbin/clixon_backend -FD $DBG -s startup -l e # logs on docker logs
+/usr/local/sbin/clixon_backend -D $DBG -s startup -l e # logs on docker logs
+
+ssh-keygen -A
+exec /usr/sbin/sshd -D -e "$@"
 
 # Alt: let backend be in foreground, but then you cannot restart
-/bin/sleep 100000000
+#/bin/sleep 100000000

--- a/openconfig/src/sshd_config
+++ b/openconfig/src/sshd_config
@@ -1,0 +1,12 @@
+AuthorizedKeysFile	.ssh/authorized_keys
+AllowTcpForwarding no
+GatewayPorts no
+X11Forwarding no
+Subsystem	sftp	internal-sftp
+PasswordAuthentication yes
+PubkeyAuthentication yes
+Subsystem netconf /usr/local/bin/clixon_netconf -f /usr/local/etc/clixon.xml
+Port 22
+Port 830
+Match LocalPort 830
+  ForceCommand /usr/local/bin/clixon_netconf -f /usr/local/etc/clixon.xml


### PR DESCRIPTION
- adds a user noc with password noc (permissions issue requires chown in entrypoint script)
- backgrounds clixon_backend and instead runs ssh in foreground
- enables netconf subsystem for ssh, forces netconf over ssh port 830